### PR TITLE
LLM app interface integration

### DIFF
--- a/aibox/controller.py
+++ b/aibox/controller.py
@@ -47,6 +47,8 @@ from unidepth_estimator import UniDepthEstimator # metric
 from midas_estimator import MidasDepthEstimator # relative
 from midas.run import create_side_by_side
 
+# Context-Aware LLM Navigation Interface integration
+from llm_interface import llm_guidance_interface
 
 def beginning_sound():
     file = 'resources/sound/beginning.mp3'
@@ -149,6 +151,8 @@ class TaskController(AutoAssign):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.variables = ['object_class', 'start_time', 'navigation_time', 'freezing_time', 'grasping_time', 'end_time', 'key']
+        self.use_llm = kwargs.get('use_llm', False)
+        self.llm_interface = llm_guidance_interface.LLMGuidanceInterface() if self.use_llm else None
 
     
     def save_output_data(self):
@@ -380,10 +384,11 @@ class TaskController(AutoAssign):
         # Initialize vars for tracking
         prev_frames = None
         curr_frames = None
+        vibration_timer = None
         fpss = []
         outputs = []
         prev_outputs = np.array([])
-
+        
         self.ready_for_next_trial = True
         self.target_entered = True # counter intuitive, but setting as True to wait for press of "s" button to start first trial
         self.class_target_obj = -1 # placeholder value not assigned to any specific object
@@ -517,7 +522,7 @@ class TaskController(AutoAssign):
 
             # Get the target object class
             if not self.target_entered:
-                if self.manual_entry:
+                if self.manual_entry and not self.use_llm:
                     user_in = "n"
                     while user_in == "n":
                         print("These are the available objects:")
@@ -532,7 +537,7 @@ class TaskController(AutoAssign):
                             # Start trial time measure (end in navigate_hand(...))
                         else:
                             print(f'The object {target_obj_verb} is not in the list of available targets. Please reselect.')
-                else:
+                elif not self.manual_entry and not self.use_llm:
                     target_obj_verb = self.target_objs[self.obj_index]
                     self.class_target_obj = next(key for key, value in coco_labels.items() if value == target_obj_verb)
                     file = f'resources/sound/{target_obj_verb}.mp3'
@@ -596,7 +601,39 @@ class TaskController(AutoAssign):
                     print(key_queue)
                 """
 
+                # Check both CV2 key input and LLM interface
                 pressed_key = cv2.waitKey(1)
+                
+                # Check LLM interface output queue
+                if self.use_llm and not self.llm_interface.output_queue.empty():
+                    llm_command = self.llm_interface.output_queue.get()
+                    print(f"Received command from LLM: {llm_command!r}")
+                    if llm_command == 's':
+                        pressed_key = ord('s')
+                    elif llm_command == 'y':
+                        pressed_key = ord('y')
+                    elif llm_command == 'n':
+                        pressed_key = ord('n')
+                    elif llm_command == 'f':
+                        pressed_key = ord('f')
+                    elif llm_command == 't':
+                        pressed_key = ord('t')
+                    elif llm_command == 'c':
+                        pressed_key = ord('c')
+                    else:
+                        # Handle object selection
+                        try:
+                            object_id = int(llm_command)
+                            if object_id in [1, 39, 40, 41, 42, 45, 46, 47, 58, 74]: # valid object IDs
+                                self.target_obj_verb = coco_labels[object_id]
+                                self.class_target_obj = object_id
+                                self.output_data.append(self.class_target_obj)
+                                self.target_entered = True
+                                self.classes_obj = [self.class_target_obj]
+                                print(f"Selected target object: {self.target_obj_verb} (ID: {object_id})")
+                        except ValueError:
+                            print(f"Invalid object ID from LLM interface: {llm_command}")
+                
                 trial_info = self.experiment_trial_logic(pressed_key)
                 
                 if trial_info == "break":
@@ -624,15 +661,19 @@ class TaskController(AutoAssign):
 
     @smart_inference_mode()
     def run(self):
-
+        # Initialize experiment variables
+        self.obj_index = 0
+        
         # Experiment setup
-        if not self.manual_entry:
-            target_objs = self.target_objs
-            self.obj_index = 0
-            print(f'The experiment will be run automatically. The selected target objects, in sequence, are:\n{target_objs}')
-        else:
+        if self.use_llm:
+            self.llm_interface.start()
+            print('The experiment will be run via the LLM interface. You can type in natural language to control the experiment.')
+        elif self.manual_entry:
             print('The experiment will be run manually. You will enter the desired target for each run yourself.')
-
+        else:
+            target_objs = self.target_objs
+            print(f'The experiment will be run automatically. The selected target objects, in sequence, are:\n{target_objs}')
+        
         horizontal_in, vertical_in = False, False
         self.target_entered = False
         #play_start()  # play welcome sound

--- a/aibox/llm_interface/llm_guidance_interface.py
+++ b/aibox/llm_interface/llm_guidance_interface.py
@@ -1,0 +1,98 @@
+import asyncio
+import threading
+from queue import Queue
+from typing import Optional
+from llm_interface import llm_interface_client
+
+class LLMGuidanceInterface:
+    def __init__(self):
+        self.input_queue = Queue()
+        self.output_queue = Queue() # queue for commands to be sent back to the system
+        self.llm_client: Optional[llm_interface_client.LLMInterfaceClient] = None
+        self.running = False
+        self.input_thread: Optional[threading.Thread] = None
+        self.llm_thread: Optional[threading.Thread] = None
+
+    def start(self):
+        """Start the interface threads"""
+        self.running = True
+        self.input_thread = threading.Thread(target=self._input_loop)
+        self.llm_thread = threading.Thread(target=self._llm_loop)
+        self.input_thread.start()
+        self.llm_thread.start()
+
+    def stop(self):
+        """Stop the interface threads"""
+        self.running = False
+        if self.input_thread:
+            self.input_thread.join()
+        if self.llm_thread:
+            self.llm_thread.join()
+
+    def _input_loop(self):
+        """Listen for console input"""
+        while self.running:
+            try:
+                user_input = input()
+                self.input_queue.put(user_input)
+            except EOFError:
+                continue
+
+    def _llm_loop(self):
+        """Process input and communicate with LLM interface"""
+        async def run_llm():
+            async with llm_interface_client.LLMInterfaceClient() as client:
+                self.llm_client = client
+                while self.running:
+                    if not self.input_queue.empty():
+                        user_input = self.input_queue.get()
+                        try:
+                            response = await client.invoke(user_input)
+                            command = self._handle_llm_response(response)
+                            print(f"Interpreted command: {command!r}")
+                            if command:
+                                print(f"Sending command to system: {command!r}")
+                                self.output_queue.put(command)
+                        except Exception as e:
+                            print(f"Error communicating with LLM interface: {e}")
+                    await asyncio.sleep(0.1)
+
+        asyncio.run(run_llm())
+
+    def _handle_llm_response(self, response: dict):
+        """Get the command key from LLM response"""
+        try:
+            # Get the last AI message content
+            messages = response.get("output", {}).get("messages", [])
+            print(f"Processing response with {len(messages)} messages")
+            ai_messages = [m for m in messages if m.get("type") == "ai"]
+            print(f"Found {len(ai_messages)} AI messages")
+            
+            if not ai_messages:
+                print("No AI messages found in response")
+                return None
+                
+            last_message = ai_messages[-1]
+            content = last_message.get("content", "").strip()
+            print(f"Raw command content: {content!r}")
+            
+            # Check if content is a valid command
+            valid_commands = {'s', 'y', 'n', 'f', 't', 'c'}
+            
+            # Check if content is a valid object ID
+            try:
+                object_id = int(content)
+                if object_id in {1, 39, 40, 41, 42, 45, 46, 47, 58, 74}:
+                    return content # return object ID as a string
+            except ValueError:
+                pass # not an object ID, continue checking other commands
+            # After checking for object ID, check for standard commands
+            if content in valid_commands:
+                return content
+            else:
+                print("Not a valid command or object ID, ignoring")
+                return None
+            
+        except Exception as e:
+            print(f"Error handling LLM response: {e}")
+            return None

--- a/aibox/llm_interface/llm_interface_client.py
+++ b/aibox/llm_interface/llm_interface_client.py
@@ -1,6 +1,7 @@
 import aiohttp
 import json
 from typing import Optional, Dict, Any
+from labels import coco_labels
 
 class LLMInterfaceClient:
     """
@@ -46,6 +47,31 @@ class LLMInterfaceClient:
                 self.token = data["access_token"]
             else:
                 raise Exception("Authentication failed")
+
+    def _get_additional_data(self, label: str) -> Dict[str, Any]:
+        """Get additional data based on the function label"""
+        if label == "object-and-hand-recognition":
+            valid_object_ids = [1, 39, 40, 41, 42, 45, 46, 47, 58, 74] # Same as classes_obj in master.py
+
+            return {
+                "available_objects": [
+                    {"id": str(id), "name": coco_labels[id], "description": f"A {coco_labels[id]} that can be {'grasped' if id in [39, 41, 45] else 'detected'}"} 
+                    for id in valid_object_ids
+                ]
+            }
+        elif label == "command-interface":
+            return {
+                "available_commands": [
+                    {"command": "s", "description": "Start a new trial"},
+                    {"command": "y", "description": "Confirm successful grasp"},
+                    {"command": "n", "description": "Indicate failed grasp"},
+                    {"command": "t", "description": "Wrong target was grasped"},
+                    {"command": "f", "description": "System failure occurred"},
+                    {"command": "q", "description": "Quit the system"},
+                    {"command": "c", "description": "Cancel current trial"}
+                ]
+            }
+        return {}
 
     async def invoke(self, message: str) -> Dict[Any, Any]:
         """

--- a/aibox/llm_interface/llm_interface_client.py
+++ b/aibox/llm_interface/llm_interface_client.py
@@ -1,0 +1,156 @@
+import aiohttp
+import json
+from typing import Optional, Dict, Any
+
+class LLMInterfaceClient:
+    """
+    Client for communicating with the Context-Aware LLM Navigation Interface for Accessibility Apps.
+    Handles authentication, message passing, and response processing.
+    https://github.com/RillJ/llm-app-interface
+    """
+    def __init__(self, base_url: str = "http://localhost:8000", username: str = "johndoe", password: str = "secret"):
+        """
+        Initialize the LLM interface client.
+        
+        Args:
+            base_url: URL of the LLM API server
+            username: Authentication username
+            password: Authentication password
+        """
+        self.base_url = base_url
+        self.username = username
+        self.password = password
+        self.token: Optional[str] = None # JWT token for authentication
+        self.session: Optional[aiohttp.ClientSession] = None # HTTP session for requests
+
+    async def __aenter__(self):
+        self.session = aiohttp.ClientSession()
+        await self.authenticate()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self.session:
+            await self.session.close()
+
+    async def authenticate(self):
+        """Get JWT token for API authentication"""
+        if not self.session:
+            return
+
+        async with self.session.post(
+            f"{self.base_url}/token",
+            data={"username": self.username, "password": self.password}
+        ) as response:
+            if response.status == 200:
+                data = await response.json()
+                self.token = data["access_token"]
+            else:
+                raise Exception("Authentication failed")
+
+    async def invoke(self, message: str) -> Dict[Any, Any]:
+        """
+        Send a message to the LLM API and handle the response flow.
+        
+        This method implements a two-step communication process:
+        1. First request to get function metadata and check if additional data is needed
+        2. Second request (if needed) to send additional context data to the LLM
+        
+        Args:
+            message: The user's input message to process
+            
+        Returns:
+            Dict containing the LLM's response with messages and any additional data
+            
+        Raises:
+            Exception: If not authenticated or if API calls fail
+        """
+        if not self.session or not self.token:
+            raise Exception("Not authenticated")
+
+        # Set up authentication and content type headers
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json"
+        }
+
+        # Prepare initial request body with user message
+        request_body = {
+            "input": {
+                "messages": message
+            }
+        }
+        
+        # Get the function metadata and determine if we need additional data
+        async with self.session.post(
+            f"{self.base_url}/llm-app-interface/invoke",
+            headers=headers,
+            json=request_body
+        ) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                raise Exception(f"API call failed with status {response.status}: {error_text}")
+            
+            # Parse the metadata response
+            metadata = await response.json()
+            # Response format is "label=X; additional-data-required=Y"
+            if isinstance(metadata, dict) and "output" in metadata:
+                content = metadata["output"].get("messages", [])[-1].get("content", "")
+                parts = content.split(";")
+                label = "" # Function label
+                needs_data = False # Flag indicating if additional context is needed
+                
+                for part in parts:
+                    if "label=" in part:
+                        label = part.split("=")[1].strip()
+                    elif "additional-data-required=" in part:
+                        needs_data = part.split("=")[1].strip().lower() == "true"
+
+            # If additional context is needed, prepare and send it
+            if needs_data:
+                print(f"\nLLM requires additional data for {label}")
+                # Get the appropriate additional data based on the function label
+                additional_data = self._get_additional_data(label)
+                # Format the data with <App> prefix as expected by the LLM
+                app_message = f"<App>{json.dumps(additional_data)}"
+                # Prepare new request with the additional context
+                request_body = {
+                    "input": {
+                        "messages": app_message
+                    }
+                }
+                print(f"Sending additional data: {app_message}\n")
+                
+                # Make the request again with the additional data
+                async with self.session.post(
+                    f"{self.base_url}/llm-app-interface/invoke",
+                    headers=headers,
+                    json=request_body
+                ) as response:
+                    if response.status == 200:
+                        response_data = await response.json()
+                        # Get the last AI message content
+                        if response_data.get("output", {}).get("messages"):
+                            messages = response_data["output"]["messages"]
+                            ai_messages = [m for m in messages if m.get("type") == "ai"]
+                            if ai_messages:
+                                last_message = ai_messages[-1]
+                                print(f"\nLLM Response: {last_message.get('content')}\n")
+                        return response_data
+                    else:
+                        error_text = await response.text()
+                        raise Exception(f"API call failed with status {response.status}: {error_text}")
+            else:
+                # No additional data needed, just process the response
+                if response.status == 200:
+                    response_data = await response.json()
+                    # Get the last AI message content
+                    if response_data.get("output", {}).get("messages"):
+                        messages = response_data["output"]["messages"]
+                        ai_messages = [m for m in messages if m.get("type") == "ai"]
+                        if ai_messages:
+                            last_message = ai_messages[-1]
+                            print(f"\nLLM Response: {last_message.get('content')}\n")
+                    return response_data
+                else:
+                    error_text = await response.text()
+                    raise Exception(f"API call failed with status {response.status}: {error_text}")

--- a/aibox/master.py
+++ b/aibox/master.py
@@ -142,7 +142,8 @@ if __name__ == '__main__':
                         half=False,  # use FP16 half-precision inference
                         dnn=False,  # use OpenCV DNN for ONNX inference
                         vid_stride=1,  # video frame-rate stride_obj
-                        manual_entry=False, # True means you will control the exp manually versus the standard automatic running
+                        use_llm=True, # whether to use the LLM interface to augment the instructions
+                        manual_entry=True, # True means you will control the exp manually versus the standard automatic running
                         run_object_tracker=run_object_tracker,
                         run_depth_estimator=run_depth_estimator,
                         mock_navigate=mock_navigate,

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ torchvision==0.17.0
 torchaudio==2.2.0
 --index-url https://download.pytorch.org/whl/cu118
 xformers
+aiohttp


### PR DESCRIPTION
These commits integrate the [Context-Aware LLM Navigation Interface for Accessibility Apps](https://github.com/RillJ/llm-app-interface) into HANS, allowing for natural language control of the system, like selecting objects, starting trials and giving feedback on trials.

- The `use_llm` flag in `master.py` enables control via the LLM interface. The [interface server](https://github.com/RillJ/llm-app-interface/blob/main/serve.py) must be running.
- The API client code looks for a server on `localhost:8000`. This can be changed in `llm_interface/llm_interface_client.py`.